### PR TITLE
Fixes issue 57 (sd not showing subcategories)

### DIFF
--- a/includes/DbService.php
+++ b/includes/DbService.php
@@ -144,9 +144,9 @@ END;
 		foreach ( $res as $row ) {
 			if ( $get_categories ) {
 				$subcategories[] = $row->page_title;
-				$pages[] = $row->page_namespace;
+				$pages[] = $row->page_title;
 			} else {
-				if ( $row->page_title == NS_CATEGORY ) {
+				if ( $row->page_namespace == NS_CATEGORY ) {
 					$subcategories[] = $row->page_title;
 				} else {
 					$pages[] = $row->page_title;

--- a/includes/DbService.php
+++ b/includes/DbService.php
@@ -97,8 +97,6 @@ END;
 	 * set of filters and either a new subcategory or a new filter.
 	 */
 	public function getNumResults( $subcategory, $subcategories, $new_filter = null ) {
-		// Escape the given values to prevent SQL injection
-		$subcategory = $this->dbr->addQuotes( $subcategory );
 		foreach ( $subcategories as $key => $value ) {
 			$subcategories[$key] = $this->dbr->addQuotes( $value );
 		}

--- a/includes/DbService.php
+++ b/includes/DbService.php
@@ -97,10 +97,6 @@ END;
 	 * set of filters and either a new subcategory or a new filter.
 	 */
 	public function getNumResults( $subcategory, $subcategories, $new_filter = null ) {
-		foreach ( $subcategories as $key => $value ) {
-			$subcategories[$key] = $this->dbr->addQuotes( $value );
-		}
-
 		$sql = "SELECT COUNT(DISTINCT sdv.id) ";
 		if ( $new_filter ) {
 			$sql .= SqlProvider::getSQLFromClauseForField( $new_filter );

--- a/tests/phpunit/Integration/JSONScript/TestCases/display-of-subcategories.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/display-of-subcategories.json
@@ -37,7 +37,7 @@
 			"assert-output": {
 				"to-contain": [
 					"Text:",
-					"<p><strong>Subcategory:</strong> <a href=\"/mediawiki/index.php/Special:BrowseData/ParentCategory?_subcat=SubCategory\" title=\"Filter by this subcategory\">SubCategory (2)</a></p>"
+					"<p><strong>Subcategory:</strong> <a href=\"/index.php/Special:BrowseData/ParentCategory?_subcat=SubCategory\" title=\"Filter by this subcategory\">SubCategory (2)</a></p>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/display-of-subcategories.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/display-of-subcategories.json
@@ -1,0 +1,53 @@
+{
+	"description": "display of subcategories",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "SomeText",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "ParentCategory",
+			"contents": "{{#drilldowninfo: filters=Text (property=SomeText)|display parameters=format=list}}"
+		},
+		{
+			"namespace": "NS_CATEGORY",
+			"page": "SubCategory",
+			"contents": "[[Category:ParentCategory]] {{#drilldowninfo: filters=Text (property=SomeText)|display parameters=format=list}}"
+		},
+		{
+			"page": "Page a",
+			"contents": "[[Category:SubCategory]][[SomeText::A]]"
+		},
+		{
+			"page": "Page b",
+			"contents": "[[Category:SubCategory]][[SomeText::B]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "no filter applied",
+			"special-page": {
+				"page": "BrowseData",
+				"query-parameters": "ParentCategory",
+				"request-parameters": {}
+			},
+			"assert-output": {
+				"to-contain": [
+					"Text:",
+					"<p><strong>Subcategory:</strong> <a href=\"/mediawiki/index.php/Special:BrowseData/ParentCategory?_subcat=SubCategory\" title=\"Filter by this subcategory\">SubCategory (2)</a></p>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
fixes https://github.com/SemanticMediaWiki/SemanticDrilldown/issues/57
`addQuotes`  in DbService -> getNumResults
`$subcategory = $this->dbr->addQuotes( $subcategory );`
is already added in `SqlProvider::getSQLFromClauseForCategory`

the following 
```
foreach ( $res as $row ) {
			if ( $get_categories ) {
				$subcategories[] = $row->page_title;
				$pages[] = $row->page_title;
			} else {
				if ( $row->page_namespace == NS_CATEGORY ) {
```
(DbService -> getCategoryChildren)

has been fixed comparing with version 1.5
https://github.com/SemanticMediaWiki/SemanticDrilldown/blob/3c5361ad0ddfe047f5cb82f84426359dd14656b5/includes/SD_Utils.php

(SDUtils -> getCategoryChildren)



