### PR TITLE
change submodule URL to use HTTPS auth

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "build"]
 	path = build
-	url = git@github.com:gesinn-it-pub/docker-compose-ci.git
+	url = https://github.com/gesinn-it-pub/docker-compose-ci.git


### PR DESCRIPTION
When trying to 'deploy' a Meza instance, the Semantic Drilldown extension causes a fatal due to failure to clone the submodule into 'build'. The git URL needs an encryption key for authentication and thus fails. Changing the definition of the submodule to use use an HTTPS URL succeeds.

Here's example log output of the failure:
```
        "name": "SemanticDrilldown",
        "repo": "https://github.com/SemanticMediaWiki/SemanticDrilldown.git",
Failed to init/update submodules: Cloning into '/opt/htdocs/mediawiki/extensions/SemanticDrilldown/build'...
fatal: clone of 'git@github.com:gesinn-it-pub/docker-compose-ci.git' into submodule path '/opt/htdocs/mediawiki/extensions/SemanticDrilldown/build' failed
Cloning into '/opt/htdocs/mediawiki/extensions/SemanticDrilldown/build'...
fatal: clone of 'git@github.com:gesinn-it-pub/docker-compose-ci.git' into submodule path '/opt/htdocs/mediawiki/extensions/SemanticDrilldown/build' failed
```

I'm not sure how such a change would impact your CI auth setup.