### PR TITLE
Replace DB_MASTER with DB_PRIMARY

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -34,7 +34,7 @@
 		Set severity to 0 instead of excluding the rule entirely so that libup does not
 		try to autofix this in the future.
 	-->
-	<rule ref="MediaWiki.Usage.DeprecatedConstantUsage.DB_MASTER">
+	<rule ref="MediaWiki.Usage.DeprecatedConstantUsage.DB_PRIMARY">
 		<severity>0</severity>
 	</rule>
 

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -27,17 +27,6 @@
 		</properties>
 	</rule>
 
-	<!--
-		Since there is no extension.json with a minimum required version, the sniff
-		assumes that the extension requires the latest version. This can be fixed once
-		this extension requires MediaWiki 1.36+ and can use DB_PRIMARY.
-		Set severity to 0 instead of excluding the rule entirely so that libup does not
-		try to autofix this in the future.
-	-->
-	<rule ref="MediaWiki.Usage.DeprecatedConstantUsage.DB_PRIMARY">
-		<severity>0</severity>
-	</rule>
-
 	<file>includes</file>
 	<file>languages</file>
 	<file>tests/phpunit</file>

--- a/includes/Filter.php
+++ b/includes/Filter.php
@@ -101,7 +101,7 @@ class Filter {
 		$possible_dates = [];
 		$property_value = $this->escapedProperty();
 		$date_field = PropertyTypeDbInfo::dateField( $this->propertyType() );
-		$dbw = wfGetDB( DB_MASTER );
+		$dbw = wfGetDB( DB_PRIMARY );
 		list( $yearValue, $monthValue, $dayValue ) = SqlProvider::getDateFunctions( $date_field );
 		$fields = "$yearValue, $monthValue, $dayValue";
 		$datesTable = $dbw->tableName( PropertyTypeDbInfo::tableName( $this->propertyType() ) );
@@ -227,7 +227,7 @@ END;
 	public function getAllValues(): PossibleFilterValues {
 		$possible_values = [];
 		$property_value = $this->escapedProperty();
-		$dbw = wfGetDB( DB_MASTER );
+		$dbw = wfGetDB( DB_PRIMARY );
 		$property_table_name = $dbw->tableName( PropertyTypeDbInfo::tableName( $this->propertyType() ) );
 		$revision_table_name = $dbw->tableName( 'revision' );
 		$page_props_table_name = $dbw->tableName( 'page_props' );
@@ -270,7 +270,7 @@ END;
 	}
 
 	private function getTimePeriod() {
-		$dbw = wfGetDB( DB_MASTER );
+		$dbw = wfGetDB( DB_PRIMARY );
 		$property_value = $this->escapedProperty();
 		$date_field = PropertyTypeDbInfo::dateField( $this->propertyType() );
 		$datesTable = $dbw->tableName( PropertyTypeDbInfo::tableName( $this->propertyType() ) );

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "SemanticDrilldown",
 			"devDependencies": {
 				"eslint-config-wikimedia": "^0.20.0",
 				"grunt-banana-checker": "^0.9.0"


### PR DESCRIPTION
DB_MASTER was deprecated in MediaWiki 1.36 and removed in MediaWiki 1.43