### PR TITLE
Issue 71 - fix deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         if: matrix.coverage == true
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: coverage/php/coverage.xml
         if: matrix.coverage == true

--- a/includes/AppliedFilter.php
+++ b/includes/AppliedFilter.php
@@ -97,7 +97,7 @@ class AppliedFilter {
 	 * @phan-return array{year:int,month:int,day:int}|null
 	 */
 	protected function parseUpperOrLowerDate( $raw_date, $is_upper ) {
-		$parts = array_filter( array_map( 'intval', explode( '-', $raw_date ) ) );
+		$parts = array_filter( array_map( 'intval', explode( '-', $raw_date ?? '' ) ) );
 		if ( !$parts ) {
 			return null;
 		}
@@ -309,7 +309,7 @@ class AppliedFilter {
 			$possible_values[] = new PossibleFilterValue(
 				$value_string,
 				null,
-				htmlspecialchars_decode( $row['displayTitle'] )
+				htmlspecialchars_decode( $row['displayTitle'] ?? '' )
 			);
 		}
 		return new PossibleFilterValues( $possible_values );

--- a/includes/Filter.php
+++ b/includes/Filter.php
@@ -270,7 +270,7 @@ END;
 			if ( $value_string === '' ) {
 				continue;
 			}
-			$possible_values[] = new PossibleFilterValue( $value_string, $row['count'], htmlspecialchars_decode( $row['displayTitle'] ) );
+			$possible_values[] = new PossibleFilterValue( $value_string, $row['count'], htmlspecialchars_decode( $row['displayTitle'] ?? '' ) );
 		}
 
 		return new PossibleFilterValues( $possible_values );

--- a/includes/Services.php
+++ b/includes/Services.php
@@ -123,8 +123,8 @@ class Services {
 	private function getGetPageFromTitleText(): Closure {
 		return static function ( string $text ) {
 			$title = Title::newFromText( $text );
-			// use appropriate WikiPage function, factory() is deprecated and not exists in MW 1.42
-			if ( version_compare( MW_VERSION, '1.42', '<' ) ) {
+			// use appropriate WikiPage function, factory() is deprecated and not exists from MW 1.36
+			if ( version_compare( MW_VERSION, '1.36', '<' ) ) {
 				return WikiPage::factory( $title );
 			}
 			if ( method_exists( WikiPageFactory::class, 'newFromTitle' ) ) {

--- a/includes/Specials/BrowseData/GetAppliedFilters.php
+++ b/includes/Specials/BrowseData/GetAppliedFilters.php
@@ -94,7 +94,7 @@ class GetAppliedFilters {
 		if ( $propertyType === 'page' ) {
 			$title = Title::newFromText( $value );
 			$displayTitle = $this->pageProps->getProperties( $title, 'displaytitle' );
-			$value = $displayTitle === [] ? $value : htmlspecialchars_decode( array_values( $displayTitle )[0] );
+			$value = $displayTitle === [] ? $value : htmlspecialchars_decode( array_values( $displayTitle )[0] ?? '' );
 		}
 
 		return Utils::getNiceFilterValue( $propertyType, $value );

--- a/includes/Specials/BrowseData/SpecialBrowseData.php
+++ b/includes/Specials/BrowseData/SpecialBrowseData.php
@@ -61,7 +61,7 @@ class SpecialBrowseData extends IncludableSpecialPage {
 
 		// get information on current category, subcategory and filters
 		// that have already been applied from the query string
-		$category = str_replace( '_', ' ', $request->getVal( '_cat' ) );
+		$category = str_replace( '_', ' ', $request->getVal( '_cat' ) ?? '' );
 		// if query string did not contain this variables, try the URL
 		if ( !$category ) {
 			$queryparts = explode( '/', $query, 1 );

--- a/includes/Utils.php
+++ b/includes/Utils.php
@@ -222,7 +222,7 @@ class Utils {
 	 * @return string
 	 */
 	public static function escapeString( $val ) {
-		return htmlspecialchars( $val, ENT_QUOTES, 'UTF-8' );
+		return htmlspecialchars( $val ?? '', ENT_QUOTES, 'UTF-8' );
 	}
 
 	/**


### PR DESCRIPTION
This PR is related to the issue number #71. 

This PR contains:

- fix passing null as a param deprecation warning for all reported functions
- update codecove action from `v3` to `v4` in `ci.yml`
- fix `WikiPage::factory()` deprecation warning in `Services.php` file