### PR TITLE
Issue 82 - remove legacy code for MW < 1.39

### DIFF
--- a/includes/Filter.php
+++ b/includes/Filter.php
@@ -337,11 +337,11 @@ END;
 		// default), in case there is no type set for this property.
 		$propertyType = 'page';
 
-		$store = Utils::getSMWStore();
+		$store = smwfGetStore();
 		$escapedProperty = $this->escapedProperty();
 		$propPage = new SMWDIWikiPage( $escapedProperty, SMW_NS_PROPERTY, '' );
 		$types = $store->getPropertyValues( $propPage, new SMWDIProperty( '_TYPE' ) );
-		$datatypeLabels = Utils::getSMWContLang()->getDatatypeLabels();
+		$datatypeLabels = smwfContLang()->getDatatypeLabels();
 		if ( count( $types ) > 0 ) {
 			if ( $types[0] instanceof SMWDIWikiPage ) {
 				$typeValue = $types[0]->getDBkey();

--- a/includes/Services.php
+++ b/includes/Services.php
@@ -114,7 +114,6 @@ class Services {
 	}
 
 	private function getPageProps(): PageProps {
-		// MW > 1.35
 		return method_exists( $this->services, 'getPageProps' )
 			? $this->services->getPageProps()
 			: PageProps::getInstance();
@@ -123,10 +122,6 @@ class Services {
 	private function getGetPageFromTitleText(): Closure {
 		return static function ( string $text ) {
 			$title = Title::newFromText( $text );
-			// use appropriate WikiPage function, factory() is deprecated and not exists from MW 1.36
-			if ( version_compare( MW_VERSION, '1.36', '<' ) ) {
-				return WikiPage::factory( $title );
-			}
 			if ( method_exists( WikiPageFactory::class, 'newFromTitle' ) ) {
 				return MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $title );
 			}

--- a/includes/Services.php
+++ b/includes/Services.php
@@ -17,7 +17,6 @@ use SpecialPage;
 use Title;
 use WebRequest;
 use Wikimedia\Rdbms\DBConnRef;
-use WikiPage;
 
 /**
  * The service locator of the SemanticDrilldown extension.

--- a/includes/Specials/BrowseData/SemanticResultPrinter.php
+++ b/includes/Specials/BrowseData/SemanticResultPrinter.php
@@ -3,7 +3,6 @@
 namespace SD\Specials\BrowseData;
 
 use Closure;
-use SD\Utils;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryResult;
 use SMWDIWikiPage;
@@ -55,7 +54,7 @@ class SemanticResultPrinter {
 	private static function createGetSmwQueryResult( $res, $num ) {
 		$qr = [];
 		$count = 0;
-		$store = Utils::getSMWStore();
+		$store = smwfGetStore();
 		while ( ( $num === null || $count < $num ) && $row = $res->fetchObject() ) {
 			$count++;
 			$qr[] = new SMWDIWikiPage( $row->t, $row->ns, '' );

--- a/includes/Utils.php
+++ b/includes/Utils.php
@@ -4,7 +4,6 @@ namespace SD;
 
 use ALItem;
 use ALRow;
-use MagicWord;
 use MagicWordFactory;
 use MediaWiki\MediaWikiServices;
 use SMW\SQLStore\SQLStore;

--- a/includes/Utils.php
+++ b/includes/Utils.php
@@ -33,25 +33,17 @@ class Utils {
 	 * @return \SMW\StoreFactory
 	 */
 	public static function getSMWStore() {
-		if ( class_exists( '\SMW\StoreFactory' ) ) {
-			// SMW 1.9+
-			return \SMW\StoreFactory::getStore();
-		} else {
-			return smwfGetStore();
-		}
+		return smwfGetStore();
 	}
 
 	/**
-	 * Helper function to have backward compatibility with SMW < 3.2
+	 * Helper function to have backward compatibility with SMW > 3.2 and MW > 1.39
 	 *
-	 * @return \SMW\Localizer\LocalLanguage\LocalLanguage
+	 * @return \SMW\Localizer\LocalLanguage\LocalLanguage Content language object
 	 */
 	public static function getSMWContLang() {
 		if ( function_exists( 'smwfContLang' ) ) {
 			return smwfContLang();
-		} else {
-			global $smwgContLang;
-			return $smwgContLang;
 		}
 	}
 
@@ -169,9 +161,6 @@ class Utils {
 			$factory = MediaWikiServices::getInstance()->getMagicWordFactory();
 			$mw_hide = $factory->get( 'MAG_HIDEFROMDRILLDOWN' );
 			$mw_show = $factory->get( 'MAG_SHOWINDRILLDOWN' );
-		} else {
-			$mw_hide = MagicWord::get( 'MAG_HIDEFROMDRILLDOWN' );
-			$mw_show = MagicWord::get( 'MAG_SHOWINDRILLDOWN' );
 		}
 		$parserOutput = $parser->getOutput();
 		if ( $mw_hide->matchAndRemove( $text ) ) {

--- a/includes/Utils.php
+++ b/includes/Utils.php
@@ -25,27 +25,6 @@ class Utils {
 		return true;
 	}
 
-	/**
-	 * Helper function to get the SMW data store for different versions
-	 * of SMW.
-	 *
-	 * @return \SMW\StoreFactory
-	 */
-	public static function getSMWStore() {
-		return smwfGetStore();
-	}
-
-	/**
-	 * Helper function to have backward compatibility with SMW > 3.2 and MW > 1.39
-	 *
-	 * @return \SMW\Localizer\LocalLanguage\LocalLanguage Content language object
-	 */
-	public static function getSMWContLang() {
-		if ( function_exists( 'smwfContLang' ) ) {
-			return smwfContLang();
-		}
-	}
-
 	public static function monthToString( $month ) {
 		if ( $month == 1 ) {
 			return wfMessage( 'january' )->text();


### PR DESCRIPTION
This PR is related to the issue #82.

The legacy code has been removed for MW < 1.39.