### PR TITLE
Fix for unittest & issue with table doesn't exist 

### DIFF
--- a/includes/DbService.php
+++ b/includes/DbService.php
@@ -66,10 +66,6 @@ class DbService {
 		$query_property = $escaped_property;
 
 		$tableName = $this->dbr->tableName( "semantic_drilldown_filter_values" );
-		$temporaryTableManager = new TemporaryTableManager( $this->dbw );
-		$sql0 = "DROP TABLE IF EXISTS $tableName";
-		$temporaryTableManager->queryWithAutoCommit( $sql0, __METHOD__ );
-
 		$sql = <<<END
  	CREATE TEMPORARY TABLE $tableName
 	AS SELECT s_id AS id, $value_field AS value
@@ -82,6 +78,7 @@ END;
 		}
 		$sql .= "	WHERE p_ids.smw_title = '$query_property'";
 
+		$temporaryTableManager = new TemporaryTableManager( $this->dbw );
 		$temporaryTableManager->queryWithAutoCommit( $sql, __METHOD__ );
 	}
 

--- a/includes/DbService.php
+++ b/includes/DbService.php
@@ -65,12 +65,13 @@ class DbService {
 
 		$query_property = $escaped_property;
 
+		$tableName = $this->dbr->tableName( "semantic_drilldown_filter_values" );
 		$temporaryTableManager = new TemporaryTableManager( $this->dbw );
-		$sql0 = "DROP TABLE IF EXISTS semantic_drilldown_filter_values";
+		$sql0 = "DROP TABLE IF EXISTS $tableName";
 		$temporaryTableManager->queryWithAutoCommit( $sql0, __METHOD__ );
 
 		$sql = <<<END
- 	CREATE TEMPORARY TABLE semantic_drilldown_filter_values
+ 	CREATE TEMPORARY TABLE $tableName
 	AS SELECT s_id AS id, $value_field AS value
 	FROM $valuesTable
 	JOIN $smw_ids p_ids ON $valuesTable.p_id = p_ids.smw_id
@@ -90,7 +91,8 @@ END;
 	public function dropFilterValuesTempTable() {
 		// DROP TEMPORARY TABLE would be marginally safer, but it's
 		// not supported on all RDBMS's.
-		$sql = "DROP TABLE semantic_drilldown_filter_values";
+		$tableName = $this->dbr->tableName( "semantic_drilldown_filter_values" );
+		$sql = "DROP TABLE $tableName";
 
 		$temporaryTableManager = new TemporaryTableManager( $this->dbw );
 		$temporaryTableManager->queryWithAutoCommit( $sql, __METHOD__ );

--- a/includes/Filter.php
+++ b/includes/Filter.php
@@ -114,9 +114,10 @@ class Filter {
 		$fields = "$yearValue, $monthValue, $dayValue";
 		$datesTable = $dbw->tableName( PropertyTypeDbInfo::tableName( $this->propertyType() ) );
 		$idsTable = $dbw->tableName( Utils::getIDsTableName() );
+		$tableName = $dbw->tableName( "semantic_drilldown_values" );
 		$sql = <<<END
 	SELECT $fields, count(*) AS matches
-	FROM semantic_drilldown_values sdv
+	FROM $tableName sdv
 	JOIN $datesTable a ON sdv.id = a.s_id
 	JOIN $idsTable p_ids ON a.p_id = p_ids.smw_id
 	WHERE p_ids.smw_title = '$property_value'
@@ -247,9 +248,10 @@ END;
 		$displaytitle = $this->propertyType === 'page' ? 'displaytitle.pp_value' : 'null';
 		$smw_ids = $dbw->tableName( Utils::getIDsTableName() );
 		$prop_ns = SMW_NS_PROPERTY;
+		$tableName = $dbw->tableName( "semantic_drilldown_values" );
 		$sql = <<<END
 	SELECT $value_field as value, $displaytitle as displayTitle, count(DISTINCT sdv.id) as count 
-	FROM semantic_drilldown_values sdv
+	FROM $tableName sdv
 	JOIN $property_table_name p ON sdv.id = p.s_id
 END;
 		if ( $this->propertyType === 'page' ) {
@@ -289,9 +291,10 @@ END;
 		$date_field = PropertyTypeDbInfo::dateField( $this->propertyType() );
 		$datesTable = $dbw->tableName( PropertyTypeDbInfo::tableName( $this->propertyType() ) );
 		$idsTable = $dbw->tableName( Utils::getIDsTableName() );
+		$tableName = $dbw->tableName( "semantic_drilldown_values" );
 		$sql = <<<END
 	SELECT MIN($date_field), MAX($date_field)
-	FROM semantic_drilldown_values sdv
+	FROM $tableName sdv
 	JOIN $datesTable a ON sdv.id = a.s_id
 	JOIN $idsTable p_ids ON a.p_id = p_ids.smw_id
 	WHERE p_ids.smw_title = '$property_value'

--- a/includes/Sql/SqlProvider.php
+++ b/includes/Sql/SqlProvider.php
@@ -32,7 +32,11 @@ class SqlProvider {
 	 * @return string
 	 */
 	public static function getSQLFromClauseForField( $new_filter ) {
-		$sql = "FROM semantic_drilldown_values sdv
+		$dbr = MediaWikiServices::getInstance()
+			->getDBLoadBalancer()
+			->getMaintenanceConnectionRef( DB_REPLICA );
+		$tableName = $dbr->tableName( "semantic_drilldown_values" );
+		$sql = "FROM $tableName sdv
 	LEFT OUTER JOIN semantic_drilldown_filter_values sdfv
 	ON sdv.id = sdfv.id
 	WHERE ";
@@ -55,7 +59,8 @@ class SqlProvider {
 		$smwCategoryInstances = $dbr->tableName( Utils::getCategoryInstancesTableName() );
 		$ns_cat = NS_CATEGORY;
 		$subcategory_escaped = $dbr->addQuotes( $subcategory );
-		$sql = "FROM semantic_drilldown_values sdv
+		$tableName = $dbr->tableName( "semantic_drilldown_values" );
+		$sql = "FROM $tableName sdv
 	JOIN $smwCategoryInstances inst
 	ON sdv.id = inst.s_id
 	WHERE inst.o_id IN

--- a/includes/Sql/SqlProvider.php
+++ b/includes/Sql/SqlProvider.php
@@ -36,8 +36,9 @@ class SqlProvider {
 			->getDBLoadBalancer()
 			->getMaintenanceConnectionRef( DB_REPLICA );
 		$tableName = $dbr->tableName( "semantic_drilldown_values" );
+		$tableNameFilter = $dbr->tableName( "semantic_drilldown_filter_values" );
 		$sql = "FROM $tableName sdv
-	LEFT OUTER JOIN semantic_drilldown_filter_values sdfv
+	LEFT OUTER JOIN $tableNameFilter sdfv
 	ON sdv.id = sdfv.id
 	WHERE ";
 		$sql .= $new_filter->checkSQL( "sdfv.value" );


### PR DESCRIPTION
i've created this pull to fix the issues in #97 

the things i've changed in this pr are:

- using DB_PRIMARY when trying to read from the temp table
- add db prefix to the table name because it fixes the unit test since it tries to truncate it and automatically adds the db prefix
- 
i'm not completely sure yet if i also need to add the db prefix also for semantic_drilldown_filter_values