### PR TITLE
Refactor deprecated DBConnection function call

### DIFF
--- a/includes/Services.php
+++ b/includes/Services.php
@@ -128,11 +128,11 @@ class Services {
 	}
 
 	private function getPrimaryDbConnectionRef(): DBConnRef {
-		return $this->services->getDBLoadBalancer()->getConnectionRef( DB_PRIMARY );
+		return $this->services->getDBLoadBalancer()->getConnection( DB_PRIMARY );
 	}
 
 	private function getReplicaDbConnectionRef(): DBConnRef {
-		return $this->services->getDBLoadBalancer()->getConnectionRef( DB_REPLICA );
+		return $this->services->getDBLoadBalancer()->getConnection( DB_REPLICA );
 	}
 
 }


### PR DESCRIPTION
The calls to `getConnectionRef` have been deprecated since MediaWiki 1.39. `getConnectionRef()` already redirects to `getConnection()`, but now we call this function directly to remove deprecation notices.