### PR TITLE
Use namespaced classes instead of deprecated class aliases

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -11,10 +11,7 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "semantic",
 	"requires": {
-		"MediaWiki": ">= 1.39",
-		"platform": {
-			"php": ">= 7.4"
-		}
+		"MediaWiki": ">= 1.43"
 	},
 	"SpecialPages": {
 		"BrowseData": "SD\\Services::getSpecialBrowseData"

--- a/includes/AppliedFilter.php
+++ b/includes/AppliedFilter.php
@@ -2,8 +2,8 @@
 
 namespace SD;
 
+use MediaWiki\Context\RequestContext;
 use MediaWiki\MediaWikiServices;
-use RequestContext;
 use SD\Sql\PropertyTypeDbInfo;
 use SD\Sql\SqlProvider;
 

--- a/includes/PageSchemas.php
+++ b/includes/PageSchemas.php
@@ -2,7 +2,7 @@
 
 namespace SD;
 
-use Html;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
 
 /**

--- a/includes/Parameters/LoadParameters.php
+++ b/includes/Parameters/LoadParameters.php
@@ -2,7 +2,9 @@
 
 namespace SD\Parameters;
 
-use PageProps;
+use MediaWiki\Page\PageProps;
+use MediaWiki\Title\Title;
+use SD\Parameters\Title as SDTitle;
 
 class LoadParameters {
 
@@ -13,9 +15,9 @@ class LoadParameters {
 	}
 
 	public function __invoke( $category ): Parameters {
-		$title = \Title::newFromText( $category, NS_CATEGORY );
+		$title = Title::newFromText( $category, NS_CATEGORY );
 		$properties = $this->pageProps->getProperties( $title, [
-			Title::PAGE_PROPERTY_NAME,
+			SDTitle::PAGE_PROPERTY_NAME,
 			Header::PAGE_PROPERTY_NAME,
 			Footer::PAGE_PROPERTY_NAME,
 			Filters::PAGE_PROPERTY_NAME,
@@ -30,7 +32,7 @@ class LoadParameters {
 		$get = fn ( $propertyName ) =>
 			array_key_exists( $propertyName, $values ) ? $values[ $propertyName ] : null;
 		return new Parameters(
-			Title::fromPropertyValue( $get( Title::PAGE_PROPERTY_NAME ) )->value,
+			SDTitle::fromPropertyValue( $get( SDTitle::PAGE_PROPERTY_NAME ) )->value,
 			Header::fromPropertyValue( $get( Header::PAGE_PROPERTY_NAME ) )->value,
 			Footer::fromPropertyValue( $get( Footer::PAGE_PROPERTY_NAME ) )->value,
 			Filters::fromPropertyValue( $get( Filters::PAGE_PROPERTY_NAME ) ),

--- a/includes/ParserFunctions/DrilldownInfo.php
+++ b/includes/ParserFunctions/DrilldownInfo.php
@@ -16,18 +16,19 @@
 
 namespace SD\ParserFunctions;
 
-use Html;
-use Parser;
+use MediaWiki\Html\Html;
+use MediaWiki\Parser\Parser;
+use MediaWiki\Title\Title;
 use SD\Parameters\DisplayParametersList;
 use SD\Parameters\Filters;
 use SD\Parameters\Footer;
 use SD\Parameters\Header;
-use SD\Parameters\Title;
+use SD\Parameters\Title as SDTitle;
 
 class DrilldownInfo {
 
 	private Parser $parser;
-	private Title $title;
+	private SDTitle $title;
 	private Filters $filters;
 	private Header $header;
 	private Footer $footer;
@@ -38,7 +39,7 @@ class DrilldownInfo {
 	}
 
 	public function __invoke( $params ): string {
-		$this->title = new Title;
+		$this->title = new SDTitle;
 		$this->filters = new Filters;
 		$this->header = new Header;
 		$this->footer = new Footer;
@@ -66,7 +67,7 @@ class DrilldownInfo {
 				continue;
 			}
 			if ( $param_name == 'title' ) {
-				$this->title = new Title( $value );
+				$this->title = new SDTitle( $value );
 			} elseif ( $param_name === 'header' ) {
 				$this->header = new Header( $value );
 			} elseif ( $param_name === 'footer' ) {
@@ -95,7 +96,7 @@ class DrilldownInfo {
 		$parserOutput->addModules( [ 'ext.semanticdrilldown.info' ] );
 
 		$text = "<table class=\"drilldownInfo mw-collapsible mw-collapsed\">\n";
-		$bd = \Title::makeTitleSafe( NS_SPECIAL, 'BrowseData' );
+		$bd = Title::makeTitleSafe( NS_SPECIAL, 'BrowseData' );
 		$bdURL = $bd->getLocalURL() . "/" . $curTitle->getPartialURL();
 		$bdLink = Html::rawElement( 'a', [ 'href' => $bdURL ], "Semantic Drilldown" );
 		$text .= "<tr><th colspan=\"2\">$bdLink</th></tr>\n";
@@ -109,10 +110,10 @@ class DrilldownInfo {
 				}
 				$text .= $key . ' = ';
 				if ( $key == 'property' ) {
-					$propertyTitle = \Title::makeTitleSafe( SMW_NS_PROPERTY, $value );
+					$propertyTitle = Title::makeTitleSafe( SMW_NS_PROPERTY, $value );
 					$text .= $this->parser->getLinkRenderer()->makeLink( $propertyTitle, $value );
 				} elseif ( $key == 'category' ) {
-					$categoryTitle = \Title::makeTitleSafe( NS_CATEGORY, $value );
+					$categoryTitle = Title::makeTitleSafe( NS_CATEGORY, $value );
 					$text .= $this->parser->getLinkRenderer()->makeLink( $categoryTitle, $value );
 				} elseif ( $key == 'requires' ) {
 					$text .= '<strong>' . $value . '</strong>';

--- a/includes/ParserFunctions/DrilldownLink.php
+++ b/includes/ParserFunctions/DrilldownLink.php
@@ -18,10 +18,10 @@
 
 namespace SD\ParserFunctions;
 
-use Html;
+use MediaWiki\Html\Html;
 use MediaWiki\MediaWikiServices;
-use Parser;
-use Sanitizer;
+use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\Sanitizer;
 
 class DrilldownLink {
 

--- a/includes/Services.php
+++ b/includes/Services.php
@@ -5,7 +5,7 @@ namespace SD;
 use Closure;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Page\WikiPageFactory;
-use PageProps;
+use MediaWiki\Title\Title;
 use SD\Parameters\LoadParameters;
 use SD\ParserFunctions\DrilldownInfo;
 use SD\ParserFunctions\DrilldownLink;
@@ -14,7 +14,6 @@ use SD\Specials\BrowseData\QueryPage;
 use SD\Specials\BrowseData\SpecialBrowseData;
 use SD\Specials\BrowseData\UrlService;
 use SpecialPage;
-use Title;
 use WebRequest;
 use Wikimedia\Rdbms\DBConnRef;
 
@@ -88,7 +87,7 @@ class Services {
 		return fn ( $context, $parameters, $query, $offset, $limit ) =>
 			new QueryPage(
 				$resultFormatTypes,
-				$this->getDbService(), $this->getPageProps(), $this->getNewUrlService(),
+				$this->getDbService(), $this->services->getPageProps(), $this->getNewUrlService(),
 				$this->getGetPageFromTitleText(),
 				$context, $parameters, $query, $offset, $limit );
 	}
@@ -109,13 +108,7 @@ class Services {
 	}
 
 	private function getLoadParameters(): LoadParameters {
-		return new LoadParameters( $this->getPageProps() );
-	}
-
-	private function getPageProps(): PageProps {
-		return method_exists( $this->services, 'getPageProps' )
-			? $this->services->getPageProps()
-			: PageProps::getInstance();
+		return new LoadParameters( $this->services->getPageProps() );
 	}
 
 	private function getGetPageFromTitleText(): Closure {

--- a/includes/Specials/BrowseData/GetApplicableFilters.php
+++ b/includes/Specials/BrowseData/GetApplicableFilters.php
@@ -2,9 +2,10 @@
 
 namespace SD\Specials\BrowseData;
 
-use Html;
+use MediaWiki\Html\Html;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\Request\WebRequest;
 use MediaWiki\Widget\DateInputWidget;
-use OutputPage;
 use SD\AppliedFilter;
 use SD\AppliedFilterValue;
 use SD\DbService;
@@ -12,7 +13,6 @@ use SD\Filter;
 use SD\PossibleFilterValue;
 use SD\PossibleFilterValues;
 use SD\Utils;
-use WebRequest;
 
 class GetApplicableFilters {
 

--- a/includes/Specials/BrowseData/GetAppliedFilters.php
+++ b/includes/Specials/BrowseData/GetAppliedFilters.php
@@ -2,9 +2,9 @@
 
 namespace SD\Specials\BrowseData;
 
-use PageProps;
+use MediaWiki\Page\PageProps;
+use MediaWiki\Title\Title;
 use SD\Utils;
-use Title;
 
 class GetAppliedFilters {
 

--- a/includes/Specials/BrowseData/GetPageContent.php
+++ b/includes/Specials/BrowseData/GetPageContent.php
@@ -3,8 +3,8 @@
 namespace SD\Specials\BrowseData;
 
 use Closure;
-use IContextSource;
-use OutputPage;
+use MediaWiki\Context\IContextSource;
+use MediaWiki\Output\OutputPage;
 
 /**
  * Return HTML and resource loader modules corresponding to a page

--- a/includes/Specials/BrowseData/GetSemanticResults.php
+++ b/includes/Specials/BrowseData/GetSemanticResults.php
@@ -2,7 +2,7 @@
 
 namespace SD\Specials\BrowseData;
 
-use OutputPage;
+use MediaWiki\Output\OutputPage;
 
 class GetSemanticResults {
 

--- a/includes/Specials/BrowseData/ProcessTemplate.php
+++ b/includes/Specials/BrowseData/ProcessTemplate.php
@@ -2,7 +2,7 @@
 
 namespace SD\Specials\BrowseData;
 
-use TemplateParser;
+use MediaWiki\Html\TemplateParser;
 
 class ProcessTemplate {
 

--- a/includes/Specials/BrowseData/QueryPage.php
+++ b/includes/Specials/BrowseData/QueryPage.php
@@ -3,8 +3,9 @@
 namespace SD\Specials\BrowseData;
 
 use Closure;
-use PageProps;
-use RequestContext;
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Page\PageProps;
+use MediaWiki\Title\Title;
 use SD\DbService;
 use SD\Parameters\DisplayParameters;
 use SD\Parameters\Parameters;
@@ -12,7 +13,6 @@ use SD\Sql\PropertyTypeDbInfo;
 use SD\Sql\SqlProvider;
 use SD\Utils;
 use SMWOutputs;
-use Title;
 use Wikimedia\Rdbms\Subquery;
 
 class QueryPage extends \QueryPage {

--- a/includes/Specials/BrowseData/SpecialBrowseData.php
+++ b/includes/Specials/BrowseData/SpecialBrowseData.php
@@ -12,8 +12,8 @@ namespace SD\Specials\BrowseData;
  */
 
 use Closure;
-use IncludableSpecialPage;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\SpecialPage\IncludableSpecialPage;
 use SD\AppliedFilter;
 use SD\BuildFilters;
 use SD\DbService;

--- a/includes/Specials/BrowseData/UrlService.php
+++ b/includes/Specials/BrowseData/UrlService.php
@@ -2,8 +2,8 @@
 
 namespace SD\Specials\BrowseData;
 
+use MediaWiki\Request\WebRequest;
 use SD\AppliedFilterValue;
-use WebRequest;
 
 class UrlService {
 

--- a/includes/TemporaryTableManager.php
+++ b/includes/TemporaryTableManager.php
@@ -2,19 +2,19 @@
 
 namespace SD;
 
-use DatabaseBase;
+use Wikimedia\Rdbms\Database;
 
 /**
  * Provides helper method to execute SQL queries in auto-commit mode
  */
 
 class TemporaryTableManager {
-	/** @var \Wikimedia\Rdbms\IDatabase|DatabaseBase */
+	/** @var \Wikimedia\Rdbms\IDatabase|Database */
 	private $databaseConnection;
 
 	/**
 	 * TemporaryTableManager constructor.
-	 * @param \Wikimedia\Rdbms\IDatabase|DatabaseBase $databaseConnection the DB connection to execute queries against
+	 * @param \Wikimedia\Rdbms\IDatabase|Database $databaseConnection the DB connection to execute queries against
 	 */
 	public function __construct( $databaseConnection ) {
 		$this->databaseConnection = $databaseConnection;

--- a/tests/phpunit/Unit/TemporaryTableManagerTest.php
+++ b/tests/phpunit/Unit/TemporaryTableManagerTest.php
@@ -2,17 +2,17 @@
 
 namespace SD\Tests\Unit;
 
-use DatabaseBase;
 use PHPUnit;
 use SD\TemporaryTableManager;
 use Wikimedia;
+use Wikimedia\Rdbms\Database;
 use const DBO_TRX;
 
 /**
  * @covers \SD\TemporaryTableManager
  */
 class TemporaryTableManagerTest extends PHPUnit\Framework\TestCase {
-	/** @var DatabaseBase|\Wikimedia\Rdbms\IDatabase */
+	/** @var Database|\Wikimedia\Rdbms\IDatabase */
 	private $databaseConnectionMock;
 
 	/** @var TemporaryTableManager */


### PR DESCRIPTION
Fix compatibility with MW 1.44.
Raise MW requirement to 1.43.
Remove redundant PHP version requirement (MW 1.43 requires PHP 8.1). Remove redundant hack for MW < 1.36 in Services.php. Closes #118.