### PR TITLE
tests: override `$wgArticlePath` manually

### DIFF
--- a/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JsonTestCaseScriptRunnerTest.php
@@ -27,6 +27,7 @@ class JsonTestCaseScriptRunnerTest extends JSONScriptTestCaseRunnerTest {
 
 	protected function getPermittedSettings() {
 		return array_merge( parent::getPermittedSettings(), [
+			"wgArticlePath",
 			"wgRestrictDisplayTitle",
 			"sdgHideCategoriesByDefault",
 			"sdgHideFiltersWithoutValues",

--- a/tests/phpunit/Integration/JSONScript/ProblematicTestCases/test2.json
+++ b/tests/phpunit/Integration/JSONScript/ProblematicTestCases/test2.json
@@ -45,6 +45,7 @@
 		}
 	],
 	"settings": {
+		"wgArticlePath": "/index.php/$1",
 		"wgLang": "en"
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/browsedata-display-of-categories-default.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/browsedata-display-of-categories-default.json
@@ -41,6 +41,7 @@
 		}
 	],
 	"settings": {
+		"wgArticlePath": "/index.php/$1",
 		"wgLang": "en"
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/browsedata-display-of-subcategories.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/browsedata-display-of-subcategories.json
@@ -43,6 +43,7 @@
 		}
 	],
 	"settings": {
+		"wgArticlePath": "/index.php/$1",
 		"wgLang": "en"
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/drilldowninfo-display-title-for-page-type-properties-with-combobox.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/drilldowninfo-display-title-for-page-type-properties-with-combobox.json
@@ -91,6 +91,7 @@
 		}
 	],
 	"settings": {
+		"wgArticlePath": "/index.php/$1",
 		"wgLang": "en",
 		"wgRestrictDisplayTitle": false,
 		"sdgMinValuesForComboBox": 0

--- a/tests/phpunit/Integration/JSONScript/TestCases/drilldowninfo-display-title-for-page-type-properties.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/drilldowninfo-display-title-for-page-type-properties.json
@@ -85,6 +85,7 @@
 		}
 	],
 	"settings": {
+		"wgArticlePath": "/index.php/$1",
 		"wgLang": "en",
 		"wgRestrictDisplayTitle": false
 	},

--- a/tests/phpunit/Integration/JSONScript/TestCases/drilldowninfo-display_parameters.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/drilldowninfo-display_parameters.json
@@ -69,6 +69,7 @@
 		}
 	],
 	"settings": {
+		"wgArticlePath": "/index.php/$1",
 		"wgLang": "en"
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/drilldowninfo-filter-values-with-special-characters.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/drilldowninfo-filter-values-with-special-characters.json
@@ -83,6 +83,7 @@
 		}
 	],
 	"settings": {
+		"wgArticlePath": "/index.php/$1",
 		"wgLang": "en"
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/drilldownlink.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/drilldownlink.json
@@ -61,6 +61,7 @@
         }
     ],
     "settings": {
+		"wgArticlePath": "/index.php/$1",
         "wgLang": "en"
     },
     "meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/filters.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/filters.json
@@ -339,6 +339,7 @@
 		}
 	],
 	"settings": {
+		"wgArticlePath": "/index.php/$1",
 		"wgLang": "en"
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/paged-and-unpaged-result-formats.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/paged-and-unpaged-result-formats.json
@@ -116,6 +116,7 @@
 		}
 	],
 	"settings": {
+		"wgArticlePath": "/index.php/$1",
 		"wgLang": "en",
 		"sdgResultFormatTypes": {
 			"ul": "unpaged",

--- a/tests/phpunit/Integration/JSONScript/TestCases/protection-against-attacks.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/protection-against-attacks.json
@@ -56,6 +56,7 @@
 		}
 	],
 	"settings": {
+		"wgArticlePath": "/index.php/$1",
 		"wgLang": "en"
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/result-formats.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/result-formats.json
@@ -270,6 +270,7 @@
 		}
 	],
 	"settings": {
+		"wgArticlePath": "/index.php/$1",
 		"wgLang": "en",
 		"wgDevelopmentWarnings": false
 	},


### PR DESCRIPTION
$wgArticlePath is set to /wiki/$1 by default in integration tests, even if a different value is specified in LocalSettings.php. This change was introduced in https://gerrit.wikimedia.org/r/c/mediawiki/core/+/967324 (MW >= 1.43). Since the integration tests still expect /index.php/$1 to be the article path, manually override the variable in the test class to ensure it is set to the correct value when the test is run.

Issue: #115