### PR TITLE
fix: correct PageSchema filter args, add unit tests, bump dev deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,16 @@
 	"homepage": "https://www.mediawiki.org/wiki/Extension:Semantic_Drilldown",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"php": ">=7.4"
+		"php": ">=8.1"
 	},
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "44.0.0",
-		"mediawiki/mediawiki-phan-config": "0.14.0",
-		"mediawiki/minus-x": "1.1.3",
+		"mediawiki/mediawiki-codesniffer": "50.0.0",
+		"mediawiki/mediawiki-phan-config": "0.20.0",
+		"mediawiki/minus-x": "2.0.1",
 		"php-parallel-lint/php-console-highlighter": "1.0.0",
 		"php-parallel-lint/php-parallel-lint": "1.4.0",
-		"phpstan/phpstan": "^1.7",
-		"vimeo/psalm": "^4.23"
+		"phpstan/phpstan": "^2.1",
+		"vimeo/psalm": "^6.0"
 	},
 	"config": {
 		"process-timeout": 0,

--- a/includes/AppliedFilter.php
+++ b/includes/AppliedFilter.php
@@ -13,7 +13,6 @@ use SD\Sql\SqlProvider;
  *
  * @author Yaron Koren
  */
-
 class AppliedFilter {
 
 	/**

--- a/includes/AppliedFilterValue.php
+++ b/includes/AppliedFilterValue.php
@@ -8,7 +8,6 @@ namespace SD;
  *
  * @author Yaron Koren
  */
-
 class AppliedFilterValue {
 	/**
 	 * The text.
@@ -71,7 +70,7 @@ class AppliedFilterValue {
 	 */
 	public $end_year = null;
 
-	public static function create( $actual_val, Filter $filter = null ) {
+	public static function create( $actual_val, ?Filter $filter = null ) {
 		$fv = new AppliedFilterValue();
 		$fv->text = str_replace( '_', ' ', $actual_val );
 
@@ -167,7 +166,7 @@ class AppliedFilterValue {
 
 		if ( $fv1->year != null && $fv2->year != null ) {
 			if ( $fv1->year == $fv2->year ) {
-				if ( $fv1->month == $fv1->month ) {
+				if ( $fv1->month == $fv2->month ) {
 					return 0;
 				}
 				return ( $fv1->month > $fv2->month ) ? 1 : -1;

--- a/includes/BuildFilters.php
+++ b/includes/BuildFilters.php
@@ -106,10 +106,10 @@ class BuildFilters {
 				$result[] = ( $this->newFilter )(
 					$name,
 					$property,
-					$propertyType,
 					$category,
 					null,
 					null,
+					$propertyType,
 					$timePeriod,
 					$allowedValues
 				);

--- a/includes/Filter.php
+++ b/includes/Filter.php
@@ -14,7 +14,6 @@ use SMWDIUri;
  *
  * @author Yaron Koren
  */
-
 class Filter {
 	private string $name;
 	private string $property;

--- a/includes/PageSchemas.php
+++ b/includes/PageSchemas.php
@@ -12,7 +12,6 @@ use MediaWiki\MediaWikiServices;
  * @author Yaron Koren
  * @author Ankit Garg
  */
-
 class PageSchemas extends \PSExtensionHandler {
 	public static function registerClass() {
 		global $wgPageSchemasHandlerClasses;

--- a/includes/Parameters/DisplayParametersList.php
+++ b/includes/Parameters/DisplayParametersList.php
@@ -9,7 +9,6 @@ class DisplayParametersList extends Parameter implements IteratorAggregate {
 
 	public const PAGE_PROPERTY_NAME = 'SDDisplayParams';
 
-	/** @readonly */
 	private array $list = [];
 
 	/**
@@ -24,7 +23,7 @@ class DisplayParametersList extends Parameter implements IteratorAggregate {
 
 	protected function propertyValue(): ?string {
 		return empty( $this->list ) ? null
-			: implode( '|', array_map( fn ( $dps ) => "$dps", $this->list ) );
+			: implode( '|', array_map( static fn ( $dps ) => "$dps", $this->list ) );
 	}
 
 	public static function fromPropertyValue( ?string $value ): self {

--- a/includes/Parameters/Filters.php
+++ b/includes/Parameters/Filters.php
@@ -41,7 +41,7 @@ class Filters extends Parameter implements IteratorAggregate {
 
 	public function getIterator(): Generator {
 		foreach ( $this->filters as $name => $settings ) {
-			$value = fn ( $key ) => array_key_exists( $key, $settings ) ? $settings[ $key ] : null;
+			$value = static fn ( $key ) => array_key_exists( $key, $settings ) ? $settings[ $key ] : null;
 			yield new Filter( $name,
 				$value( 'property' ),
 				$value( 'category' ),

--- a/includes/Parameters/LoadParameters.php
+++ b/includes/Parameters/LoadParameters.php
@@ -29,7 +29,7 @@ class LoadParameters {
 		}
 
 		$values = array_values( $properties )[0];
-		$get = fn ( $propertyName ) =>
+		$get = static fn ( $propertyName ) =>
 			array_key_exists( $propertyName, $values ) ? $values[ $propertyName ] : null;
 		return new Parameters(
 			SDTitle::fromPropertyValue( $get( SDTitle::PAGE_PROPERTY_NAME ) )->value,

--- a/includes/Parameters/SimpleParameter.php
+++ b/includes/Parameters/SimpleParameter.php
@@ -8,8 +8,7 @@ namespace SD\Parameters;
  */
 class SimpleParameter extends Parameter {
 
-	/** @readonly */
-	public ?string $value;
+	public readonly ?string $value;
 
 	public function __construct( ?string $value = null ) {
 		$this->value = $value;

--- a/includes/PossibleFilterValues.php
+++ b/includes/PossibleFilterValues.php
@@ -48,8 +48,8 @@ class PossibleFilterValues implements IteratorAggregate {
 	 */
 	public function countRange(): array {
 		return [
-			min( array_map( fn ( $v ) => $v->count(), $this->values ) ),
-			max( array_map( fn ( $v ) => $v->count(), $this->values ) )
+				min( array_map( static fn ( $v ) => $v->count(), $this->values ) ),
+				max( array_map( static fn ( $v ) => $v->count(), $this->values ) )
 		];
 	}
 

--- a/includes/Services.php
+++ b/includes/Services.php
@@ -47,7 +47,7 @@ class Services {
 	public static function onParserFirstCallInit( $parser ) {
 		foreach ( self::PARSER_FUNCTIONS as $name => $class ) {
 			$parser->setFunctionHook( $name,
-				fn ( $parser, ...$params ) => ( new $class( $parser ) )( $params ) );
+				static fn ( $parser, ...$params ) => ( new $class( $parser ) )( $params ) );
 		}
 	}
 
@@ -69,7 +69,7 @@ class Services {
 	}
 
 	private function getGetPageSchema(): Closure {
-		return fn ( $category ) => class_exists( 'PSSchema' ) ? new \PSSchema( $category ) : null;
+		return static fn ( $category ) => class_exists( 'PSSchema' ) ? new \PSSchema( $category ) : null;
 	}
 
 	private function getNewQuery(): Closure {
@@ -94,7 +94,7 @@ class Services {
 
 	private function getNewUrlService(): Closure {
         // phpcs:ignore MediaWiki.Usage.AssignmentInReturn.AssignmentInReturn
-		return fn ( WebRequest $request, ?DrilldownQuery $query = null ) =>
+		return static fn ( WebRequest $request, ?DrilldownQuery $query = null ) =>
 			new UrlService(
 				SpecialPage::getTitleFor( 'BrowseData' )->getLocalURL(), $request, $query );
 	}

--- a/includes/Specials/BrowseData/QueryPage.php
+++ b/includes/Specials/BrowseData/QueryPage.php
@@ -102,9 +102,9 @@ class QueryPage extends \QueryPage {
 	protected function getPageHeader(): string {
 		$vm = [
 			'displayParametersWithUnknownFormat' =>
-				array_map( fn ( $x ) => "$x", $this->displayParametersWithUnknownFormat ),
-			'displayParametersWithUnsupportedFormat' =>
-				array_map( fn ( $x ) => "$x", $this->displayParametersWithUnsupportedFormat ),
+					array_map( static fn ( $x ) => "$x", $this->displayParametersWithUnknownFormat ),
+				'displayParametersWithUnsupportedFormat' =>
+					array_map( static fn ( $x ) => "$x", $this->displayParametersWithUnsupportedFormat ),
 			'header' => $this->getPageContent( $this->getOutput(), $this->headerPage ),
 		];
 

--- a/includes/TemporaryTableManager.php
+++ b/includes/TemporaryTableManager.php
@@ -7,7 +7,6 @@ use Wikimedia\Rdbms\Database;
 /**
  * Provides helper method to execute SQL queries in auto-commit mode
  */
-
 class TemporaryTableManager {
 	/** @var \Wikimedia\Rdbms\IDatabase|Database */
 	private $databaseConnection;

--- a/includes/Utils.php
+++ b/includes/Utils.php
@@ -12,7 +12,6 @@ use SMW\SQLStore\SQLStore;
  *
  * @author Yaron Koren
  */
-
 class Utils {
 
 	public static function setGlobalJSVariables( &$vars ) {

--- a/tests/phpunit/Unit/AppliedFilterTest.php
+++ b/tests/phpunit/Unit/AppliedFilterTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace SD\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use SD\AppliedFilter;
+use SD\Filter;
+
+/**
+ * @covers \SD\AppliedFilter
+ */
+class AppliedFilterTest extends TestCase {
+
+	// ---------------------------------------------------------------------------
+	// Helpers
+	// ---------------------------------------------------------------------------
+
+	private function filterWithType( string $type ): Filter {
+		$filter = $this->createMock( Filter::class );
+		$filter->method( 'propertyType' )->willReturn( $type );
+		return $filter;
+	}
+
+	/**
+	 * Call a protected method via reflection.
+	 * @return mixed
+	 */
+	private function callProtected( object $obj, string $method, array $args = [] ) {
+		$rm = new ReflectionMethod( $obj, $method );
+		$rm->setAccessible( true );
+		return $rm->invokeArgs( $obj, $args );
+	}
+
+	private function newAppliedFilter(): AppliedFilter {
+		return new AppliedFilter();
+	}
+
+	// ---------------------------------------------------------------------------
+	// Tests – parseUpperOrLowerDate()
+	// ---------------------------------------------------------------------------
+
+	public function testParseUpperOrLowerDateNullReturnsNull(): void {
+		$result = $this->callProtected( $this->newAppliedFilter(), 'parseUpperOrLowerDate', [ null, false ] );
+		$this->assertNull( $result );
+	}
+
+	public function testParseUpperOrLowerDateEmptyStringReturnsNull(): void {
+		$result = $this->callProtected( $this->newAppliedFilter(), 'parseUpperOrLowerDate', [ '', false ] );
+		$this->assertNull( $result );
+	}
+
+	public function testParseUpperOrLowerDateFullDateLower(): void {
+		$result = $this->callProtected( $this->newAppliedFilter(), 'parseUpperOrLowerDate', [ '2020-06-15', false ] );
+		$this->assertSame( [ 'year' => 2020, 'month' => 6, 'day' => 15 ], $result );
+	}
+
+	public function testParseUpperOrLowerDateFullDateUpper(): void {
+		$result = $this->callProtected( $this->newAppliedFilter(), 'parseUpperOrLowerDate', [ '2020-06-15', true ] );
+		$this->assertSame( [ 'year' => 2020, 'month' => 6, 'day' => 15 ], $result );
+	}
+
+	public function testParseUpperOrLowerDateYearOnlyLowerDefaultsToJanFirst(): void {
+		$result = $this->callProtected( $this->newAppliedFilter(), 'parseUpperOrLowerDate', [ '2020', false ] );
+		$this->assertSame( [ 'year' => 2020, 'month' => 1, 'day' => 1 ], $result );
+	}
+
+	public function testParseUpperOrLowerDateYearOnlyUpperDefaultsToDecLast(): void {
+		$result = $this->callProtected( $this->newAppliedFilter(), 'parseUpperOrLowerDate', [ '2020', true ] );
+		$this->assertSame( [ 'year' => 2020, 'month' => 12, 'day' => 31 ], $result );
+	}
+
+	public function testParseUpperOrLowerDateYearMonthLowerDefaultsDayToFirst(): void {
+		$result = $this->callProtected( $this->newAppliedFilter(), 'parseUpperOrLowerDate', [ '2020-06', false ] );
+		$this->assertSame( [ 'year' => 2020, 'month' => 6, 'day' => 1 ], $result );
+	}
+
+	public function testParseUpperOrLowerDateYearMonthUpperDefaultsDayToLast(): void {
+		$result = $this->callProtected( $this->newAppliedFilter(), 'parseUpperOrLowerDate', [ '2020-06', true ] );
+		$this->assertSame( [ 'year' => 2020, 'month' => 6, 'day' => 31 ], $result );
+	}
+
+	// ---------------------------------------------------------------------------
+	// Tests – lowerOrUpperDateToSql()
+	// ---------------------------------------------------------------------------
+
+	public function testLowerOrUpperDateToSql(): void {
+		$date = [ 'year' => 2020, 'month' => 6, 'day' => 15 ];
+		$result = $this->callProtected( $this->newAppliedFilter(), 'lowerOrUpperDateToSql', [ $date ] );
+		$this->assertSame( "DATE('2020-6-15')", $result );
+	}
+
+	// ---------------------------------------------------------------------------
+	// Tests – create(): value construction
+	// ---------------------------------------------------------------------------
+
+	public function testCreateWithSingleStringValueCreatesOneFilterValue(): void {
+		$filter = $this->filterWithType( 'text' );
+		$af = AppliedFilter::create( $filter, 'hello' );
+		$this->assertCount( 1, $af->values );
+		$this->assertSame( 'hello', $af->values[0]->text );
+	}
+
+	public function testCreateWithArrayOfValuesCreatesMultipleFilterValues(): void {
+		$filter = $this->filterWithType( 'text' );
+		$af = AppliedFilter::create( $filter, [ 'alpha', 'beta', 'gamma' ] );
+		$this->assertCount( 3, $af->values );
+		$this->assertSame( 'alpha', $af->values[0]->text );
+		$this->assertSame( 'beta', $af->values[1]->text );
+		$this->assertSame( 'gamma', $af->values[2]->text );
+	}
+
+	public function testCreateWithSearchTerms(): void {
+		$filter = $this->filterWithType( 'text' );
+		$af = AppliedFilter::create( $filter, [], [ 'foo', 'bar' ] );
+		$this->assertSame( [ 'foo', 'bar' ], $af->search_terms );
+	}
+
+	public function testCreateWithNullDatesLeavesDateFieldsNull(): void {
+		$filter = $this->filterWithType( 'text' );
+		$af = AppliedFilter::create( $filter, [], null, null, null );
+		$this->assertNull( $af->lower_date );
+		$this->assertNull( $af->upper_date );
+	}
+
+	public function testCreateWithInvalidDateStringLeavesDateFieldsNull(): void {
+		$filter = $this->filterWithType( 'text' );
+		$af = AppliedFilter::create( $filter, [], null, '', '' );
+		$this->assertNull( $af->lower_date );
+		$this->assertNull( $af->upper_date );
+	}
+
+	public function testCreateStoresFilterReference(): void {
+		$filter = $this->filterWithType( 'page' );
+		$af = AppliedFilter::create( $filter, 'val' );
+		$this->assertSame( $filter, $af->filter );
+	}
+
+	public function testCreateWithUnderscoreValueDecodesInFilterValue(): void {
+		$filter = $this->filterWithType( 'page' );
+		$af = AppliedFilter::create( $filter, 'hello_world' );
+		$this->assertSame( 'hello world', $af->values[0]->text );
+	}
+}

--- a/tests/phpunit/Unit/AppliedFilterValueTest.php
+++ b/tests/phpunit/Unit/AppliedFilterValueTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace SD\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use SD\AppliedFilterValue;
+use SD\Filter;
+
+/**
+ * @covers \SD\AppliedFilterValue
+ */
+class AppliedFilterValueTest extends TestCase {
+
+	// ---------------------------------------------------------------------------
+	// Helpers
+	// ---------------------------------------------------------------------------
+
+	private function filterWithType( string $type ): Filter {
+		$filter = $this->createMock( Filter::class );
+		$filter->method( 'propertyType' )->willReturn( $type );
+		return $filter;
+	}
+
+	// ---------------------------------------------------------------------------
+	// Tests – create(): plain text / special values
+	// ---------------------------------------------------------------------------
+
+	public function testCreateReplacesUnderscoresWithSpaces(): void {
+		$fv = AppliedFilterValue::create( 'hello_world' );
+		$this->assertSame( 'hello world', $fv->text );
+	}
+
+	public function testCreateNoneValue(): void {
+		$fv = AppliedFilterValue::create( '_none' );
+		$this->assertTrue( $fv->is_none );
+		$this->assertFalse( $fv->is_other );
+	}
+
+	public function testCreateOtherValue(): void {
+		$fv = AppliedFilterValue::create( '_other' );
+		$this->assertTrue( $fv->is_other );
+		$this->assertFalse( $fv->is_none );
+	}
+
+	public function testCreatePlainTextWithoutFilter(): void {
+		$fv = AppliedFilterValue::create( 'some value' );
+		$this->assertSame( 'some value', $fv->text );
+		$this->assertFalse( $fv->is_none );
+		$this->assertFalse( $fv->is_other );
+		$this->assertFalse( $fv->is_numeric );
+	}
+
+	public function testCreateEmptyStringWithPageFilter(): void {
+		$fv = AppliedFilterValue::create( '', $this->filterWithType( 'page' ) );
+		$this->assertSame( '', $fv->text );
+		$this->assertFalse( $fv->is_numeric );
+		$this->assertNull( $fv->lower_limit );
+		$this->assertNull( $fv->upper_limit );
+	}
+
+	// ---------------------------------------------------------------------------
+	// Tests – create(): numeric ranges (non-date filter)
+	// ---------------------------------------------------------------------------
+
+	public function testCreateUpperLimitNumeric(): void {
+		$fv = AppliedFilterValue::create( '<100', $this->filterWithType( 'page' ) );
+		$this->assertTrue( $fv->is_numeric );
+		$this->assertNull( $fv->lower_limit );
+		$this->assertSame( '100', $fv->upper_limit );
+	}
+
+	public function testCreateUpperLimitWithCommasStripped(): void {
+		$fv = AppliedFilterValue::create( '<1,000', $this->filterWithType( 'page' ) );
+		$this->assertTrue( $fv->is_numeric );
+		$this->assertSame( '1000', $fv->upper_limit );
+	}
+
+	public function testCreateUpperLimitNonNumericNotSetAsNumeric(): void {
+		$fv = AppliedFilterValue::create( '<abc', $this->filterWithType( 'page' ) );
+		$this->assertFalse( $fv->is_numeric );
+		$this->assertNull( $fv->upper_limit );
+	}
+
+	public function testCreateLowerLimitNumeric(): void {
+		$fv = AppliedFilterValue::create( '>50', $this->filterWithType( 'page' ) );
+		$this->assertTrue( $fv->is_numeric );
+		$this->assertSame( '50', $fv->lower_limit );
+		$this->assertNull( $fv->upper_limit );
+	}
+
+	public function testCreateLowerLimitNonNumericNotSetAsNumeric(): void {
+		$fv = AppliedFilterValue::create( '>abc', $this->filterWithType( 'page' ) );
+		$this->assertFalse( $fv->is_numeric );
+		$this->assertNull( $fv->lower_limit );
+	}
+
+	public function testCreateNumericRange(): void {
+		$fv = AppliedFilterValue::create( '100-200', $this->filterWithType( 'page' ) );
+		$this->assertTrue( $fv->is_numeric );
+		$this->assertSame( '100', $fv->lower_limit );
+		$this->assertSame( '200', $fv->upper_limit );
+	}
+
+	public function testCreateNumericRangeWithCommas(): void {
+		$fv = AppliedFilterValue::create( '1,000-2,000', $this->filterWithType( 'page' ) );
+		$this->assertTrue( $fv->is_numeric );
+		$this->assertSame( '1000', $fv->lower_limit );
+		$this->assertSame( '2000', $fv->upper_limit );
+	}
+
+	public function testCreateNonNumericRangeNotSetAsNumeric(): void {
+		$fv = AppliedFilterValue::create( 'abc-def', $this->filterWithType( 'page' ) );
+		$this->assertFalse( $fv->is_numeric );
+		$this->assertNull( $fv->lower_limit );
+		$this->assertNull( $fv->upper_limit );
+	}
+
+	public function testCreateTextWithoutAnySpecialPattern(): void {
+		$fv = AppliedFilterValue::create( 'Berlin', $this->filterWithType( 'page' ) );
+		$this->assertFalse( $fv->is_numeric );
+		$this->assertSame( 'Berlin', $fv->text );
+	}
+
+	// ---------------------------------------------------------------------------
+	// Tests – compare()
+	// ---------------------------------------------------------------------------
+
+	private function fv( array $props ): AppliedFilterValue {
+		$fv = new AppliedFilterValue();
+		foreach ( $props as $k => $v ) {
+			$fv->$k = $v;
+		}
+		return $fv;
+	}
+
+	public function testCompareFirstIsNoneReturnPositive(): void {
+		$result = AppliedFilterValue::compare(
+			$this->fv( [ 'is_none' => true ] ),
+			$this->fv( [ 'text' => 'A' ] )
+		);
+		$this->assertGreaterThan( 0, $result );
+	}
+
+	public function testCompareSecondIsNoneReturnNegative(): void {
+		$result = AppliedFilterValue::compare(
+			$this->fv( [ 'text' => 'A' ] ),
+			$this->fv( [ 'is_none' => true ] )
+		);
+		$this->assertLessThan( 0, $result );
+	}
+
+	public function testCompareFirstIsOtherReturnPositive(): void {
+		$result = AppliedFilterValue::compare(
+			$this->fv( [ 'is_other' => true ] ),
+			$this->fv( [ 'text' => 'A' ] )
+		);
+		$this->assertGreaterThan( 0, $result );
+	}
+
+	public function testCompareSecondIsOtherReturnNegative(): void {
+		$result = AppliedFilterValue::compare(
+			$this->fv( [ 'text' => 'A' ] ),
+			$this->fv( [ 'is_other' => true ] )
+		);
+		$this->assertLessThan( 0, $result );
+	}
+
+	public function testCompareByYearLater(): void {
+		$result = AppliedFilterValue::compare(
+			$this->fv( [ 'year' => 2020, 'month' => 1 ] ),
+			$this->fv( [ 'year' => 2010, 'month' => 1 ] )
+		);
+		$this->assertGreaterThan( 0, $result );
+	}
+
+	public function testCompareByYearEarlier(): void {
+		$result = AppliedFilterValue::compare(
+			$this->fv( [ 'year' => 2010, 'month' => 1 ] ),
+			$this->fv( [ 'year' => 2020, 'month' => 1 ] )
+		);
+		$this->assertLessThan( 0, $result );
+	}
+
+	public function testCompareSameYearLaterMonth(): void {
+		$result = AppliedFilterValue::compare(
+			$this->fv( [ 'year' => 2020, 'month' => 6 ] ),
+			$this->fv( [ 'year' => 2020, 'month' => 3 ] )
+		);
+		$this->assertGreaterThan( 0, $result );
+	}
+
+	public function testCompareSameYearEarlierMonth(): void {
+		$result = AppliedFilterValue::compare(
+			$this->fv( [ 'year' => 2020, 'month' => 3 ] ),
+			$this->fv( [ 'year' => 2020, 'month' => 6 ] )
+		);
+		$this->assertLessThan( 0, $result );
+	}
+
+	public function testCompareSameYearSameMonthReturnsZero(): void {
+		$result = AppliedFilterValue::compare(
+			$this->fv( [ 'year' => 2020, 'month' => 6 ] ),
+			$this->fv( [ 'year' => 2020, 'month' => 6 ] )
+		);
+		$this->assertSame( 0, $result );
+	}
+
+	public function testCompareNumericByLowerLimit(): void {
+		$result = AppliedFilterValue::compare(
+			$this->fv( [ 'is_numeric' => true, 'lower_limit' => '200' ] ),
+			$this->fv( [ 'is_numeric' => true, 'lower_limit' => '100' ] )
+		);
+		$this->assertGreaterThan( 0, $result );
+	}
+
+	public function testCompareNumericNullLowerLimitReturnsNegative(): void {
+		$result = AppliedFilterValue::compare(
+			$this->fv( [ 'is_numeric' => true, 'lower_limit' => null ] ),
+			$this->fv( [ 'is_numeric' => true, 'lower_limit' => '100' ] )
+		);
+		$this->assertLessThan( 0, $result );
+	}
+
+	public function testCompareTextAlphabetically(): void {
+		$result = AppliedFilterValue::compare(
+			$this->fv( [ 'text' => 'Beta' ] ),
+			$this->fv( [ 'text' => 'Alpha' ] )
+		);
+		$this->assertGreaterThan( 0, $result );
+	}
+
+	public function testCompareEqualTextReturnsZero(): void {
+		$result = AppliedFilterValue::compare(
+			$this->fv( [ 'text' => 'Same' ] ),
+			$this->fv( [ 'text' => 'Same' ] )
+		);
+		$this->assertSame( 0, $result );
+	}
+}

--- a/tests/phpunit/Unit/BuildFiltersTest.php
+++ b/tests/phpunit/Unit/BuildFiltersTest.php
@@ -1,0 +1,405 @@
+<?php
+
+namespace SD\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use SD\BuildFilters;
+use SD\Filter;
+use SD\Parameters\Filters;
+
+/**
+ * @covers \SD\BuildFilters
+ */
+class BuildFiltersTest extends TestCase {
+
+	// ---------------------------------------------------------------------------
+	// Helpers
+	// ---------------------------------------------------------------------------
+
+	/** Returns a spy closure that records all calls and returns a Filter mock per call. */
+	private function makeFilterSpy( array &$calls ): \Closure {
+		// PHPUnit mocks need $this, capture each separately so the closure stays static-compatible
+		$test = $this;
+		return static function () use ( &$calls, $test ): Filter {
+			$calls[] = func_get_args();
+			return $test->createMock( Filter::class );
+		};
+	}
+
+	/** Returns a no-schema closure (simulates extension not installed or category without schema). */
+	private function makeNoSchema(): \Closure {
+		return static fn ( $category ) => null;
+	}
+
+	/** Builds a minimal anonymous PSSchema-like object with defined templates/fields. */
+	private function makePsSchema( array $templates ): object {
+		return new class( $templates ) {
+			public function __construct( private array $templates ) {
+			}
+
+			public function isPSDefined(): bool {
+				return true;
+			}
+
+			public function getTemplates(): array {
+				return $this->templates;
+			}
+		};
+	}
+
+	/** Builds a template-like object from an array of field-like objects. */
+	private function makeTemplate( array $fields ): object {
+		return new class( $fields ) {
+			public function __construct( private array $fields ) {
+			}
+
+			public function getFields(): array {
+				return $this->fields;
+			}
+		};
+	}
+
+	/**
+	 * Builds a field-like object.
+	 *
+	 * @param string $name Field name (fallback for filter name)
+	 * @param array|null $filterArray Result of getObject('semanticdrilldown_Filter')
+	 * @param array $propArray Result of getObject('semanticmediawiki_Property')
+	 */
+	private function makeField( string $name, ?array $filterArray, array $propArray = [] ): object {
+		return new class( $name, $filterArray, $propArray ) {
+			public function __construct(
+				private string $name,
+				private ?array $filterArray,
+				private array $propArray
+			) {
+			}
+
+			public function getName(): string {
+				return $this->name;
+			}
+
+			public function getObject( string $key ): ?array {
+				return match ( $key ) {
+					'semanticdrilldown_Filter' => $this->filterArray,
+					'semanticmediawiki_Property' => $this->propArray,
+					default => null,
+				};
+			}
+		};
+	}
+
+	// ---------------------------------------------------------------------------
+	// Tests – no filters / no schema
+	// ---------------------------------------------------------------------------
+
+	public function testReturnsEmptyArrayWithNullFiltersAndNoSchema(): void {
+		$calls = [];
+		$bf = new BuildFilters( $this->makeFilterSpy( $calls ), $this->makeNoSchema() );
+
+		$result = $bf( 'TestCategory', null );
+
+		$this->assertSame( [], $result );
+		$this->assertSame( [], $calls );
+	}
+
+	public function testReturnsEmptyArrayWithEmptyFiltersAndNoSchema(): void {
+		$calls = [];
+		$bf = new BuildFilters( $this->makeFilterSpy( $calls ), $this->makeNoSchema() );
+
+		$result = $bf( 'TestCategory', new Filters() );
+
+		$this->assertSame( [], $result );
+		$this->assertSame( [], $calls );
+	}
+
+	// ---------------------------------------------------------------------------
+	// Tests – parser-function driven filters (#drilldowninfo)
+	// ---------------------------------------------------------------------------
+
+	public function testBuildsOneFilterFromFilterParameter(): void {
+		$calls = [];
+		$bf = new BuildFilters( $this->makeFilterSpy( $calls ), $this->makeNoSchema() );
+
+		$filters = new Filters( 'MyFilter(property=MyProp)' );
+		$result = $bf( 'TestCategory', $filters );
+
+		$this->assertCount( 1, $result );
+		$this->assertCount( 1, $calls );
+		$this->assertSame( 'MyFilter', $calls[0][0] );
+		$this->assertSame( 'MyProp', $calls[0][1] );
+	}
+
+	public function testBuildsMultipleFiltersFromFilterParameters(): void {
+		$calls = [];
+		$bf = new BuildFilters( $this->makeFilterSpy( $calls ), $this->makeNoSchema() );
+
+		$filters = new Filters( 'FilterA(property=PropA), FilterB(property=PropB)' );
+		$result = $bf( 'TestCategory', $filters );
+
+		$this->assertCount( 2, $result );
+		$this->assertCount( 2, $calls );
+		$this->assertSame( 'FilterA', $calls[0][0] );
+		$this->assertSame( 'FilterB', $calls[1][0] );
+	}
+
+	public function testFilterParameterPassesCategoryAndRequiresAndInt(): void {
+		$calls = [];
+		$bf = new BuildFilters( $this->makeFilterSpy( $calls ), $this->makeNoSchema() );
+
+		$filters = new Filters( 'F(property=P, category=C, requires=R, int=1)' );
+		$bf( 'TestCategory', $filters );
+
+		// $newFilter($name, $property, $category, $requiredFilters, $int)
+		$this->assertSame( 'F', $calls[0][0] );
+		$this->assertSame( 'P', $calls[0][1] );
+		$this->assertSame( 'C', $calls[0][2] );
+		$this->assertSame( 'R', $calls[0][3] );
+		$this->assertSame( '1', $calls[0][4] );
+	}
+
+	// ---------------------------------------------------------------------------
+	// Tests – PageSchema-driven filters
+	// ---------------------------------------------------------------------------
+
+	public function testReturnsEmptyArrayWhenSchemaIsNull(): void {
+		$calls = [];
+		$bf = new BuildFilters(
+			$this->makeFilterSpy( $calls ),
+			static fn ( $cat ) => null
+		);
+
+		$result = $bf( 'TestCategory', null );
+
+		$this->assertSame( [], $result );
+		$this->assertSame( [], $calls );
+	}
+
+	public function testReturnsEmptyArrayWhenSchemaIsNotPSDefined(): void {
+		$schema = new class {
+			public function isPSDefined(): bool {
+				return false;
+			}
+		};
+		$calls = [];
+		$bf = new BuildFilters(
+			$this->makeFilterSpy( $calls ),
+			static fn ( $cat ) => $schema
+		);
+
+		$result = $bf( 'TestCategory', null );
+
+		$this->assertSame( [], $result );
+		$this->assertSame( [], $calls );
+	}
+
+	public function testSkipsFieldWithoutDrilldownFilterObject(): void {
+		$field = $this->makeField( 'NoFilterField', null, [ 'name' => 'Prop', 'Type' => 'Text' ] );
+		$schema = $this->makePsSchema( [ $this->makeTemplate( [ $field ] ) ] );
+
+		$calls = [];
+		$bf = new BuildFilters( $this->makeFilterSpy( $calls ), static fn () => $schema );
+
+		$result = $bf( 'TestCategory', null );
+
+		$this->assertSame( [], $result );
+		$this->assertSame( [], $calls );
+	}
+
+	public function testPageSchemaFilterUsesFieldNameWhenFilterArrayHasNoName(): void {
+		$field = $this->makeField(
+			'FieldName',
+			// filter_array without 'name' key
+			[],
+			[ 'name' => 'PropName', 'Type' => 'Text' ]
+		);
+		$schema = $this->makePsSchema( [ $this->makeTemplate( [ $field ] ) ] );
+
+		$calls = [];
+		$bf = new BuildFilters( $this->makeFilterSpy( $calls ), static fn () => $schema );
+		$bf( 'TestCategory', null );
+
+		$this->assertSame( 'FieldName', $calls[0][0] );
+	}
+
+	public function testPageSchemaFilterUsesExplicitFilterName(): void {
+		$field = $this->makeField(
+			'FieldName',
+			[ 'name' => 'ExplicitFilterName' ],
+			[ 'name' => 'Prop', 'Type' => 'Text' ]
+		);
+		$schema = $this->makePsSchema( [ $this->makeTemplate( [ $field ] ) ] );
+
+		$calls = [];
+		$bf = new BuildFilters( $this->makeFilterSpy( $calls ), static fn () => $schema );
+		$bf( 'TestCategory', null );
+
+		$this->assertSame( 'ExplicitFilterName', $calls[0][0] );
+	}
+
+	public function testPageSchemaFilterUsesPropArrayNameForPropertyWhenNotEmpty(): void {
+		$field = $this->makeField(
+			'FieldName',
+			[],
+			[ 'name' => 'ExplicitPropName', 'Type' => 'Text' ]
+		);
+		$schema = $this->makePsSchema( [ $this->makeTemplate( [ $field ] ) ] );
+
+		$calls = [];
+		$bf = new BuildFilters( $this->makeFilterSpy( $calls ), static fn () => $schema );
+		$bf( 'TestCategory', null );
+
+		// $newFilter($name, $property, $category, $requiredFilters, $int, $propertyType, ...)
+		$this->assertSame( 'ExplicitPropName', $calls[0][1] );
+	}
+
+	public function testPageSchemaFilterFallsBackToFilterNameForPropertyWhenPropNameIsEmpty(): void {
+		$field = $this->makeField(
+			'FieldName',
+			// empty property name → falls back to filter name
+			[],
+			[ 'name' => '' ]
+		);
+		$schema = $this->makePsSchema( [ $this->makeTemplate( [ $field ] ) ] );
+
+		$calls = [];
+		$bf = new BuildFilters( $this->makeFilterSpy( $calls ), static fn () => $schema );
+		$bf( 'TestCategory', null );
+
+		$this->assertSame( 'FieldName', $calls[0][1] );
+	}
+
+	public function testPageSchemaFilterPassesPropertyTypeInCorrectPosition(): void {
+		$field = $this->makeField(
+			'F',
+			[],
+			[ 'name' => 'Prop', 'Type' => 'Page' ]
+		);
+		$schema = $this->makePsSchema( [ $this->makeTemplate( [ $field ] ) ] );
+
+		$calls = [];
+		$bf = new BuildFilters( $this->makeFilterSpy( $calls ), static fn () => $schema );
+		$bf( 'TestCategory', null );
+
+		// $newFilter($name, $property, $category, $requiredFilters, $int, $propertyType, ...)
+		// category (pos 2) should be null, propertyType (pos 5) should be 'page'
+		$this->assertNull( $calls[0][2], 'category should be null' );
+		$this->assertNull( $calls[0][3], 'requiredFilters should be null' );
+		$this->assertNull( $calls[0][4], 'int should be null' );
+		$this->assertSame( 'page', $calls[0][5], 'propertyType should be lowercased Type' );
+	}
+
+	public function testPageSchemaFilterWithValuesFromCategory(): void {
+		$field = $this->makeField(
+			'F',
+			[ 'ValuesFromCategory' => 'Animals' ],
+			[ 'name' => 'Prop' ]
+		);
+		$schema = $this->makePsSchema( [ $this->makeTemplate( [ $field ] ) ] );
+
+		$calls = [];
+		$bf = new BuildFilters( $this->makeFilterSpy( $calls ), static fn () => $schema );
+		$bf( 'TestCategory', null );
+
+		// $newFilter($name, $property, $category, ...)
+		$this->assertSame( 'Animals', $calls[0][2] );
+	}
+
+	public function testPageSchemaFilterWithTimePeriod(): void {
+		$field = $this->makeField(
+			'F',
+			[ 'TimePeriod' => 'year' ],
+			[ 'name' => 'Prop' ]
+		);
+		$schema = $this->makePsSchema( [ $this->makeTemplate( [ $field ] ) ] );
+
+		$calls = [];
+		$bf = new BuildFilters( $this->makeFilterSpy( $calls ), static fn () => $schema );
+		$bf( 'TestCategory', null );
+
+		// $newFilter($name, $property, $category, $requiredFilters, $int, $propertyType, $timePeriod, $allowedValues)
+		$this->assertSame( 'year', $calls[0][6] );
+		$this->assertSame( [], $calls[0][7] );
+	}
+
+	public function testPageSchemaFilterWithBooleanPropertyTypeUsesHardcodedAllowedValues(): void {
+		$field = $this->makeField(
+			'F',
+			// no ValuesFromCategory, no TimePeriod, no Values
+			[],
+			[ 'name' => 'Prop', 'Type' => 'Boolean' ]
+		);
+		$schema = $this->makePsSchema( [ $this->makeTemplate( [ $field ] ) ] );
+
+		$calls = [];
+		$bf = new BuildFilters( $this->makeFilterSpy( $calls ), static fn () => $schema );
+		$bf( 'TestCategory', null );
+
+		$this->assertSame( [ '0', '1' ], $calls[0][7] );
+	}
+
+	public function testPageSchemaFilterWithExplicitValues(): void {
+		$field = $this->makeField(
+			'F',
+			[ 'Values' => [ 'Alpha', 'Beta' ] ],
+			[ 'name' => 'Prop' ]
+		);
+		$schema = $this->makePsSchema( [ $this->makeTemplate( [ $field ] ) ] );
+
+		$calls = [];
+		$bf = new BuildFilters( $this->makeFilterSpy( $calls ), static fn () => $schema );
+		$bf( 'TestCategory', null );
+
+		$this->assertSame( [ 'Alpha', 'Beta' ], $calls[0][7] );
+	}
+
+	public function testPageSchemaFilterWithNoValuesFallsBackToEmptyAllowedValues(): void {
+		$field = $this->makeField(
+			'F',
+			// no ValuesFromCategory, no TimePeriod, no Values (and not boolean)
+			[],
+			[ 'name' => 'Prop' ]
+		);
+		$schema = $this->makePsSchema( [ $this->makeTemplate( [ $field ] ) ] );
+
+		$calls = [];
+		$bf = new BuildFilters( $this->makeFilterSpy( $calls ), static fn () => $schema );
+		$bf( 'TestCategory', null );
+
+		$this->assertSame( [], $calls[0][7] );
+	}
+
+	// ---------------------------------------------------------------------------
+	// Tests – merging both sources
+	// ---------------------------------------------------------------------------
+
+	public function testMergesParserFiltersWithSchemaFilters(): void {
+		$field = $this->makeField( 'SchemaFilter', [], [ 'name' => 'SchemaProp' ] );
+		$schema = $this->makePsSchema( [ $this->makeTemplate( [ $field ] ) ] );
+
+		$calls = [];
+		$bf = new BuildFilters( $this->makeFilterSpy( $calls ), static fn () => $schema );
+
+		$filters = new Filters( 'ParserFilter(property=ParserProp)' );
+		$result = $bf( 'TestCategory', $filters );
+
+		$this->assertCount( 2, $result );
+		$this->assertCount( 2, $calls );
+		// parser-function filters come first
+		$this->assertSame( 'ParserFilter', $calls[0][0] );
+		$this->assertSame( 'SchemaFilter', $calls[1][0] );
+	}
+
+	public function testPassesCategoryToGetPageSchemaCallback(): void {
+		$receivedCategory = null;
+		$getSchema = static function ( $cat ) use ( &$receivedCategory ) {
+			$receivedCategory = $cat;
+			return null;
+		};
+
+		$bf = new BuildFilters( static fn () => null, $getSchema );
+		$bf( 'ExpectedCategory', null );
+
+		$this->assertSame( 'ExpectedCategory', $receivedCategory );
+	}
+}


### PR DESCRIPTION
Fix argument order bug in BuildFilters::loadFiltersFromPageSchema(): $propertyType and $category were swapped when calling $newFilter, causing property types defined via PageSchemas to be silently ignored.

Fix self-comparison bug in AppliedFilterValue::compare() where $fv1->month was compared to itself instead of $fv2->month.

Add unit tests for BuildFilters, AppliedFilter and AppliedFilterValue covering all code paths including the fixed bugs. Coverage improves from ~31% to ~43% (classes), 76% (lines).

Bump dev dependencies and raise PHP requirement:
- PHP: >=7.4 -> >=8.1 (MW 1.43 requires 8.1)
- mediawiki/mediawiki-codesniffer: 44.0.0 -> 50.0.0
- mediawiki/mediawiki-phan-config: 0.14.0 -> 0.20.0
- mediawiki/minus-x: 1.1.3 -> 2.0.1
- phpstan/phpstan: ^1.7 -> ^2.1
- vimeo/psalm: ^4.23 -> ^6.0

Fix all new codesniffer 50 violations (blank lines before class, static closures, PHP 8.1 readonly keyword, nullable type syntax).