### PR TITLE
Fix issue with year only dates being ignored 

### DIFF
--- a/includes/Sql/PropertyTypeDbInfo.php
+++ b/includes/Sql/PropertyTypeDbInfo.php
@@ -57,7 +57,7 @@ class PropertyTypeDbInfo {
 					// segment is optional. All of these are valid: 2000, 2000/2, 2000/2/11.
 					// However, YEAR(), MONTH() and DAY() would return NULL for incomplete date,
 					// so STR_TO_DATE is required.
-					$result = "STR_TO_DATE($result, '%Y/%m/%d')";
+					$result = "STR_TO_DATE(CONCAT(SUBSTR(o_serialized, 3, 100), '/01/01'), '%Y/%m/%d')";
 				} elseif ( $wgDBtype == 'sqlite' ) {
 					// probably one of the greatest moments in software development:
 					$result = "DATE(SUBSTR(


### PR DESCRIPTION
With this fix, dates like "YYYY" are treated as YYYY/01/01 instead of being ignored in Special:BrowseData filtering.

== How to reproduce ==

1. Create a wiki page with an SMW date property set to a year-only value (e.g. "1900")
2. Open Special:BrowseData and filter by date range 1900/01/01 – 1901/12/31
3. Expected: the page appears in results, but it's excluded

Note: the page shows if you filter between 1899/12/31 and 1900/01/01.

The same issue affects month-precision dates (e.g. "1901/03").

== Root cause ==

In Sql/PropertyTypeDbInfo.php, dateField() builds the SQL date expression as:

STR_TO_DATE(SUBSTR(o_serialized, 3, 100), '%Y/%m/%d')

MySQL returns NULL when the date string is incomplete (e.g. "1525" or "1525/03"),
because the format '%Y/%m/%d' requires all three components. NULL never satisfies
a >= or <= condition, so year-precision and month-precision dates are systematically
excluded from all date range filters.

Confirmed via SQL: both "1/1900" (year-only) and "1/1900/01/01" share the same
o_sortkey value, so the issue is purely in the STR_TO_DATE parsing, not in the underlying SMW storage.

Note: Filter.php already handles this case correctly for the datepicker default values (min/max bounds), with the comment:
  "If month/day are missing in $min_date/$max_date, then set them to 1 January for $min_date and to 31 December for $max_date."
...but the actual SQL filter condition does not apply the same logic.