### PR TITLE
Fix double-encoded filter name in date range inputs

### DIFF
--- a/includes/Specials/BrowseData/GetApplicableFilters.php
+++ b/includes/Specials/BrowseData/GetApplicableFilters.php
@@ -455,7 +455,10 @@ END;
 
 		// For dates additionally add two datepicker inputs (Start/End) to select a custom interval.
 		if ( $f->propertyType() == 'date' && $possibleValues->count() != 0 ) {
-			$results_line .= '<br>' . $this->getDateRangeInput( $filter_name, $possibleValues->dateRange() );
+			# $filter_name is alread urlencoded, and getDateRangeInput applies a second urlencode()
+			# so this breaks the URL sent to the browser. Use a raw filter name instead.
+			$raw_filter_name = str_replace( ' ', '_', $f->name() );   
+			$results_line .= '<br>' . $this->getDateRangeInput( $raw_filter_name, $possibleValues->dateRange() );
 		}
 
 		$text = $this->getFilterLine( $f->name(), false, $normal_filter, $results_line, $f );


### PR DESCRIPTION
**Issue :** The filters based on datepicker range filters send wrong URLs when the date property contains special characters like accents.

**Exemple :** "?_lower_Date_de_d%25C3%25A8s" instead of "?_lower_Date_de_décès=2020-02-13..."

**Cause :** In GetApplicableFilters::getUnappliedFilterLine(), $filter_name is built with urlencode() for use in link URLs. This encoded value is also passed to getDateRangeInput(), causing the attributes to contain already-encoded characters (e.g. "Date_de_d%C3%A8s"). When the browser submits the form, it encodes them a second time (e.g. "Date_de_d%25C3%25A8s"), which no longer matches the filter name expected by SpecialBrowseData, so the date range filter has no effect.

**Fix:** pass the raw (non-encoded) filter name to getDateRangeInput(), just replacing white spaces with underscores.